### PR TITLE
Adapt to tyxml change for boolean attributes.

### DIFF
--- a/src/ew_editable.eliom
+++ b/src/ew_editable.eliom
@@ -29,7 +29,7 @@ let editable_name
     ?(cancel : 'c my_btn option)
     ?(default_name="New name") ~content ~(callback:(string -> unit Lwt.t) client_value) =
   let fake_input =
-    span ~a:[a_contenteditable `True ]
+    span ~a:[a_contenteditable true]
       [pcdata default_name] in
   let btn_icon title content =
     D.Raw.a ~a:[ a_title title ; a_class ["link"] ]


### PR DESCRIPTION
See https://github.com/ocsigen/tyxml/pull/30

Also fix this bug, under ocaml 3.12:

```
File "src/ew_editable.eliom", line 32, characters 32-37:
Error: This expression has type [> ` True ]
       but an expression was expected of type
         [< `False | `True ] Eliom_content.Html5.F.wrap
       The second variant type does not allow tag(s) ` True
```

Just for the viewing pleasure: 

``` ocaml
let of_bool = function
   | true -> `True
   | false -> `False
```

```
% eliomc -i foo.ml
val of_bool : bool -> [> ` False | ` True ]
```

```
% ocamlc -i foo.ml
val of_bool : bool -> [> `False | `True ]
```

```
% ocamlc -i -pp camlp4o foo.ml
val of_bool : bool -> [> ` False | ` True ]
```

(:
